### PR TITLE
enet: fix header installation path

### DIFF
--- a/enet/PSPBUILD
+++ b/enet/PSPBUILD
@@ -26,7 +26,7 @@ package() {
     mkdir -m 755 -p "$pkgdir/psp/lib"
     install -m 644 build/libenet.a "$pkgdir/psp/lib"
     mkdir -m 755 -p "$pkgdir/psp/include"
-    cp -R include "$pkgdir/psp/include"
+    cp -R include/enet "$pkgdir/psp/include"
 
     mkdir -m 755 -p "$pkgdir/psp/share/licenses/$pkgname"
     install -m 644 LICENSE "$pkgdir/psp/share/licenses/$pkgname"


### PR DESCRIPTION
Currently, headers are installed under `/usr/local/pspdev/psp/include/include/enet/`, and should be under `/usr/local/pspdev/psp/include/enet/`.

This is a simple fix, and it shouldn't be needed after the next version of enet is released (https://github.com/lsalzman/enet/pull/82 got merged, so the headers will be installed with `make install`).